### PR TITLE
Remove activations from Layer

### DIFF
--- a/proto/spacemesh/v1/types.proto
+++ b/proto/spacemesh/v1/types.proto
@@ -117,8 +117,7 @@ message Layer {
     LayerStatus status = 2;
     bytes hash = 3; // computer layer hash - do we need this?
     repeated Block blocks = 4; // layer's blocks
-    repeated Activation activations = 5; // list of layer's activations
-    bytes root_state_hash = 6; // when available - the root state hash of global state in this layer
+    bytes root_state_hash = 5; // when available - the root state hash of global state in this layer
 }
 
 message LayerNumber {


### PR DESCRIPTION
Closes #132

Motivation: #132, https://github.com/spacemeshos/go-spacemesh/issues/2314

Activations for a given layer is not well-defined since activations are associated with blocks and epochs, not layers. Remove this to prevent confusion. They can be read from blocks for now.