### PR TITLE
feat(api):better TransactionState.TransactionState->TransactionState.…

### DIFF
--- a/spacemesh/v1/tx_types.proto
+++ b/spacemesh/v1/tx_types.proto
@@ -43,7 +43,7 @@ message TransactionsStateStreamResponse {
 // and its side effects, check the Receipt in the GlobalStateService.
 message TransactionState {
     TransactionId id = 1;
-    enum TransactionState {
+    enum TransactionStateEnum {
         TRANSACTION_STATE_UNSPECIFIED = 0; // default state
         TRANSACTION_STATE_REJECTED = 1; // rejected from mempool due to, e.g., invalid syntax
         TRANSACTION_STATE_INSUFFICIENT_FUNDS = 2; // rejected from mempool by funds check
@@ -52,7 +52,7 @@ message TransactionState {
         TRANSACTION_STATE_MESH = 5; // submitted to the mesh
         TRANSACTION_STATE_PROCESSED = 6; // processed by STF; check Receipt for success or failure
     }
-    TransactionState state = 2;
+    TransactionStateEnum state = 2;
 }
 
 // TransactionResultsRequest request object for results stream.


### PR DESCRIPTION
I'm developing java sdk, when I try to generate java classes due to proto, it would generate illegal java code.

This is because tx_types.proto defines  TransactionState alongwith enum TransactionState:

message TransactionState {
    TransactionId id = 1;
    enum TransactionState {
        TRANSACTION_STATE_UNSPECIFIED = 0; // default state
        TRANSACTION_STATE_REJECTED = 1; // rejected from mempool due to, e.g., invalid syntax
        TRANSACTION_STATE_INSUFFICIENT_FUNDS = 2; // rejected from mempool by funds check
        TRANSACTION_STATE_CONFLICTING = 3; // rejected from mempool due to conflicting counter
        TRANSACTION_STATE_MEMPOOL = 4; // in mempool but not on the mesh yet
        TRANSACTION_STATE_MESH = 5; // submitted to the mesh
        TRANSACTION_STATE_PROCESSED = 6; // processed by STF; check Receipt for success or failure
    }
    TransactionState state = 2;
}
It would generate this form of java code which is illegal in Java:
![image](https://github.com/spacemeshos/api/assets/6778136/3af1f044-e02a-4bdc-8a7a-9d9bde761e59)



A fast way to optimize this is to change the name of the enum: TransactionState.TransactionState->TransactionState.TramsactionStateEnum